### PR TITLE
对于markdown页面，不再使用ajax请求，而是在加载页面本身时包含以节省网络流量。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config/config.py
 *.db
 *.sqlite
+*.pyc

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "master"
+    ]
+}

--- a/app.py
+++ b/app.py
@@ -7,7 +7,6 @@ from flask import Response
 from flask_socketio import SocketIO, join_room, emit, leave_room
 import utils
 import sqlite3
-import json
 
 from blueprints.share import share
 from config import *
@@ -53,7 +52,7 @@ def page_get(page):
     # 如果以.md结尾，渲染Markdown。
     if page.endswith(".md"):  # /example1.md
         # 返回包含markdown值的渲染客户端
-        return utils.text2resp(app, page, json.dumps(text), SITE_NAME, 'md_client')
+        return utils.text2resp(app, page, text, SITE_NAME, 'md_client')
     else:  # 如果不以.md结尾，则返回笔记页面。（templates/note.j2）
         return utils.text2resp(app, page, text, SITE_NAME, 'note')
 

--- a/static/js/md-client.js
+++ b/static/js/md-client.js
@@ -1,4 +1,3 @@
-var text;
 
 marked.setOptions({
   pedantic: false,
@@ -27,37 +26,32 @@ $(".content").html(`<div class="md-loading-notice" style="
                                     font-size: 10px;
                                     color: #777;
                                     font-style: oblique;
-                                ">Waiting for AJAX response...</p>
+                                ">Waiting for Markdown rendering...</p>
                         </div>`)
-$.ajax({
-    type: "GET",
-    url: "/" + page + "?md_api",
-    success: (t) => {
-        text = t;
-        let lines=text.split("\n");
-        let count = 0;
-        for (let [idx,line] of lines.entries()) {
-            let areas = line.split('$');
-            for (let [idx1, area] of areas.entries()) {
-                if (idx1 % 2) {
-                    areas[idx1] = `<span id="tex_${count}">${area}</span>`;
-                    count += 1;
-                }
-            }
-            lines[idx] = areas.join('');
-        }
-        text = lines.join("\n");
-        $(".content").html(marked.parse(text));
 
-        for (let i=0;i<count;i++) {
-            let tex=$(`#tex_${i}`).text();
-            try {
-                katex.render(tex,document.getElementById(`tex_${i}`));
-            }
-            catch {
-                console.log(`The No. ${i+1} TeX "${tex}" cannot be rendered due to a syntax error.`);
-                $(`#tex_${i}`).html(`<span style="color: #ffd700;">Invalid TeX here. See the browser console for further information.</span>`);
-            }
+
+let lines=text.split("\n");
+let count = 0;
+for (let [idx,line] of lines.entries()) {
+    let areas = line.split('$');
+    for (let [idx1, area] of areas.entries()) {
+        if (idx1 % 2) {
+            areas[idx1] = `<span id="tex_${count}">${area}</span>`;
+            count += 1;
         }
-    },
-});
+    }
+    lines[idx] = areas.join('');
+}
+text = lines.join("\n");
+$(".content").html(marked.parse(text));
+
+for (let i=0;i<count;i++) {
+    let tex=$(`#tex_${i}`).text();
+    try {
+        katex.render(tex,document.getElementById(`tex_${i}`));
+    }
+    catch {
+        console.log(`The No. ${i+1} TeX "${tex}" cannot be rendered due to a syntax error.`);
+        $(`#tex_${i}`).html(`<span style="color: #ffd700;">Invalid TeX here. See the browser console for further information.</span>`);
+    }
+}

--- a/templates/components/md_client.j2
+++ b/templates/components/md_client.j2
@@ -8,7 +8,7 @@
         </div>
     </div>
     <div class="flag">
-        <a href="/">{{ site_name }}</a>/<a href="javascript:n=decodeURIComponent(window.location.pathname);window.open('/'+n.substring(1,n.length-3)+'?save','_self')" id="footer"></a>
+        <a href="/">{{ site_name }}</a>/<a href="javascript:n=decodeURIComponent(window.location.pathname);window.open('/'+n.substring(1,n.length-3)+'?save','_self')" id="footer">{{page}}</a>
     </div>
 </div>
 <pre class="print">
@@ -16,4 +16,7 @@
 <script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-2.2.4.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
+<script>
+    var text={{ text | safe }};
+</script>
 <script src="/static/js/md-client.js"></script>

--- a/utils/member/text2resp.py
+++ b/utils/member/text2resp.py
@@ -2,6 +2,7 @@ from urllib.parse import quote_plus
 from flask import Response, render_template, request
 from ..text import link, sanitizer
 from config import *
+import json
 
 
 def text2resp(app, page, text, site_name, body):
@@ -18,7 +19,9 @@ def text2resp(app, page, text, site_name, body):
     elif request.args.get('save') is not None:
         return Response(text, mimetype='text/plain',
                         headers={"Content-disposition": f"attachment; filename*=UTF-8''{quote_plus(page)}.txt"})
-
+    elif body=="md_client":
+        text=json.dumps(sanitizer.sanitize_html(text,ALLOW_JS_MARKDOWN_LINKS));
+        return render_template("paper.html", body=body, page=page, text=text, site_name=site_name)
     else:
-        print(body,page,text)
+        #print(body,page,text)
         return render_template("paper.html", body=body, page=page, text=text, site_name=site_name)

--- a/utils/member/text2resp.py
+++ b/utils/member/text2resp.py
@@ -15,14 +15,10 @@ def text2resp(app, page, text, site_name, body):
     )):  # 给带有text参数的请求始终直接显示内容
         return Response(text, mimetype='text/plain')
 
-    elif is_md_api_request:
-        text = link.auto_link(text)
-        text = sanitizer.sanitize_html(text, remove_js_links=not ALLOW_JS_MARKDOWN_LINKS)
-        return Response(text, mimetype='text/plain')
-
     elif request.args.get('save') is not None:
         return Response(text, mimetype='text/plain',
                         headers={"Content-disposition": f"attachment; filename*=UTF-8''{quote_plus(page)}.txt"})
 
     else:
+        print(body,page,text)
         return render_template("paper.html", body=body, page=page, text=text, site_name=site_name)

--- a/utils/text/sanitizer.py
+++ b/utils/text/sanitizer.py
@@ -1,6 +1,6 @@
 from bs4 import BeautifulSoup
 import re
-import nh3
+#import nh3
 
 
 VALID_TAGS = ['strong', 'em', 'p', 'ul', 'ol', 'li', 'b', 'i',


### PR DESCRIPTION
如题，已通过本地测试，包括但不限于渲染welcome.md。
另外还把所有的处理逻辑改到了util而非路由处理程里面。